### PR TITLE
bump Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,11 +10,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.11.3)
+    backports (3.11.4)
     base64url (1.0.1)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.10.0)
     jwt (1.5.6)
     manifoldco_signature (0.1.4)
       base64url (~> 1.0.1)
@@ -29,10 +29,10 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-protection (1.5.5)
       rack
-    rack-test (1.0.0)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rbnacl (3.4.0)
       ffi
@@ -49,7 +49,7 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (>= 1.3, < 3)
-    tilt (2.0.8)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
@@ -58,4 +58,4 @@ DEPENDENCIES
   sinatra_sample_provider!
 
 BUNDLED WITH
-   1.16.2
+   2.0.1


### PR DESCRIPTION
Bump Gemfile.lock dependencies by running `bundle update`.  I then ran `bundle install` and ran the grafton test:

```
→  grafton test --product=bonnets --plan=small --region=aws::us-east-1 \
    --client-id=21jtaatqj8y5t0kctb2ejr6jev5w8 \
    --client-secret=3yTKSiJ6f5V5Bq-kWF0hmdrEUep3m3HKPTcPX7CdBZw \
    --connector-port=3001 \
    --new-plan=large \
    --resource-measures='{"feature-a": 0, "feature-b": 1000}' \
    http://localhost:4567
cleanup: Can provision and deprovision a resource
  Default case ✔
provision: Provision a resource
  Default case ✔
  Error case: with a faulty product name ✔
  Error case: with a faulty plan name ✔
  Error case: with a faulty region ✔
  Error case: with a bad signature ✔
  Error case: with an already provisioned resource - same content acts as created ✔
  Error case: with an already provisioned resource - different content results in conflict ✔
  credentials: Create a credential set
    Default case ✔
    Error case: with an invalid resource ID ✔
    Error case: with already provisioned credentials - same content acts as created ✔
    Error case: with a bad signature ✔
  credentials: Delete a credential set
    Default case ✔
    Error case: delete credentials that do not exist ✔
  resource-measures: Pull usage measures from a Resource
    Default case ✔
  plan-change: Change a resource's plan
    Default case ✔
    Error case: with existing plan - returns success ✔
    Error case: with a non existing resource ✔
    Error case: with a non existing plan ✔
    Error case: with a bad signature ✔
  plan-change: Change the resource's plan back to the original
    Default case ✔
  sso: Single Sign-On Flow
    Default case ✔
    Error case: with wrong client id ✔
    Error case: with wrong client secret ✔
    Error case: with expired token ✔
    Error case: with non-existing code ✔
    Error case: with connector response error ✔
provision: Deprovision a resource
  Default case ✔
  Error case: delete a non existing resource ✔
```